### PR TITLE
Revamp dashboard layout and add admin console

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,120 @@
-import React from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Dashboard } from "./pages/Dashboard";
+import { AdminDashboard } from "./pages/AdminDashboard";
+import { useLocalStorage } from "./hooks/useLocalStorage";
+import { api, ApiClient } from "./api/client";
+import type { Group, ShuffleResponse } from "./types";
+
+type View = "dashboard" | "admin";
 
 export default function App() {
+  const [view, setView] = useState<View>("dashboard");
+  const [baseUrl, setBaseUrl] = useLocalStorage("sims.api.baseurl", api.baseUrl);
+  const client = useMemo(() => new ApiClient(baseUrl), [baseUrl]);
+
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [simCount, setSimCount] = useState<number>(4);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const safe = useCallback(async <T,>(label: string, fn: () => Promise<T>) => {
+    setBusy(label);
+    setError(null);
+    try {
+      return await fn();
+    } catch (e) {
+      setError((e as Error).message ?? "Something went wrong");
+      throw e;
+    } finally {
+      setBusy(null);
+    }
+  }, []);
+
+  const fetchGroups = useCallback(async () => {
+    const data = await client.getGroups();
+    setGroups(data);
+    return data;
+  }, [client]);
+
+  const initialize = useCallback(() => safe("Loading groups", fetchGroups), [safe, fetchGroups]);
+
+  useEffect(() => {
+    initialize().catch(() => null);
+  }, [initialize]);
+
+  const handlePullFromSpond = useCallback(
+    () =>
+      safe("Pulling from Spond", async () => {
+        await client.pullFromSpond();
+        await fetchGroups();
+        return null;
+      }),
+    [client, fetchGroups, safe]
+  );
+
+  const handleShuffle = useCallback(
+    () =>
+      safe("Shuffling groups", async () => {
+        const res: ShuffleResponse = await client.shuffle(simCount);
+        setGroups(res.groups);
+        return res;
+      }),
+    [client, safe, simCount]
+  );
+
+  const handleLoadSaved = useCallback(
+    () => safe("Loading saved groups", fetchGroups),
+    [fetchGroups, safe]
+  );
+
   return (
-    <div className="min-h-dvh bg-white text-gray-900">
-      <Dashboard />
+    <div className="min-h-dvh bg-slate-50 text-slate-900">
+      <header className="border-b border-slate-200 bg-white/90 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl flex-col gap-3 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <div className="text-lg font-semibold tracking-tight text-slate-900">Spond Sims</div>
+            <p className="text-sm text-slate-500">Monitor simulator lineups and manage data syncing.</p>
+          </div>
+          <nav className="flex items-center gap-2 rounded-full bg-slate-100 p-1 text-sm font-medium text-slate-600">
+            <button
+              type="button"
+              onClick={() => setView("dashboard")}
+              className={`rounded-full px-4 py-1.5 transition ${
+                view === "dashboard"
+                  ? "bg-white text-slate-900 shadow"
+                  : "hover:text-slate-900 hover:shadow-sm"
+              }`}
+            >
+              Dashboard
+            </button>
+            <button
+              type="button"
+              onClick={() => setView("admin")}
+              className={`rounded-full px-4 py-1.5 transition ${
+                view === "admin" ? "bg-white text-slate-900 shadow" : "hover:text-slate-900 hover:shadow-sm"
+              }`}
+            >
+              Admin
+            </button>
+          </nav>
+        </div>
+      </header>
+
+      {view === "dashboard" ? (
+        <Dashboard groups={groups} busy={busy} error={error} />
+      ) : (
+        <AdminDashboard
+          baseUrl={baseUrl}
+          setBaseUrl={setBaseUrl}
+          simCount={simCount}
+          setSimCount={setSimCount}
+          busy={busy}
+          error={error}
+          onPullFromSpond={handlePullFromSpond}
+          onShuffle={handleShuffle}
+          onLoadSaved={handleLoadSaved}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/GroupCard.tsx
+++ b/src/components/GroupCard.tsx
@@ -4,13 +4,30 @@ import type { Group } from "../types";
 
 export const GroupCard: React.FC<{ group: Group; index?: number }> = ({ group }) => {
   return (
-    <div className="rounded-2xl border p-4 shadow-sm">
-      <div className="mb-2 text-lg font-semibold">Simulator {group.group_id}</div>
-      <ul className="list-disc pl-5 text-sm">
-        {group.members.map((m, i) => (
-          <li key={i}>{String(m.name ?? m.full_name ?? m.display_name ?? Object.values(m)[0])}</li>
-        ))}
-      </ul>
-    </div>
+    <article className="relative overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-xl transition hover:-translate-y-1 hover:shadow-2xl">
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-emerald-50 via-white to-sky-50" aria-hidden="true" />
+      <div className="relative flex h-full flex-col gap-5 p-6">
+        <div className="flex items-start justify-between">
+          <div className="text-left">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-600">Simulator</p>
+            <h2 className="text-3xl font-black text-slate-900">{group.group_id}</h2>
+          </div>
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-500/10 text-lg font-semibold text-emerald-600">
+            {group.members.length}
+          </div>
+        </div>
+
+        <ul className="flex flex-1 flex-col gap-2 text-lg font-medium text-slate-800">
+          {group.members.map((member, index) => (
+            <li key={index} className="flex items-center gap-3 rounded-2xl bg-white/60 px-3 py-2 text-left shadow-sm">
+              <span className="flex h-7 w-7 flex-none items-center justify-center rounded-full bg-emerald-500/80 text-xs font-bold uppercase tracking-widest text-white">
+                {index + 1}
+              </span>
+              <span>{String(member.name ?? member.full_name ?? member.display_name ?? Object.values(member)[0])}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </article>
   );
 };

--- a/src/components/GroupGrid.tsx
+++ b/src/components/GroupGrid.tsx
@@ -5,11 +5,16 @@ import { GroupCard } from "./GroupCard";
 
 export const GroupGrid: React.FC<{ groups: Group[] }> = ({ groups }) => {
   if (!groups?.length)
-    return <div className="text-sm italic opacity-70">No groups yet.</div>;
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 rounded-3xl border border-dashed border-slate-300 bg-white/50 p-10 text-center text-sm text-slate-500">
+        <span className="text-lg font-semibold text-slate-600">No groups yet</span>
+        <p>Once an administrator publishes a shuffle the simulators will appear here.</p>
+      </div>
+    );
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-      {groups.map((g) => (
-        <GroupCard key={g.group_id} group={g} />
+    <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+      {groups.map((group) => (
+        <GroupCard key={group.group_id} group={group} />
       ))}
     </div>
   );

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,0 +1,170 @@
+import React, { useMemo, useState } from "react";
+
+interface AdminDashboardProps {
+  baseUrl: string;
+  setBaseUrl: (url: string) => void;
+  simCount: number;
+  setSimCount: (count: number) => void;
+  busy: string | null;
+  error: string | null;
+  onPullFromSpond: () => Promise<unknown>;
+  onShuffle: () => Promise<unknown>;
+  onLoadSaved: () => Promise<unknown>;
+}
+
+const ADMIN_PASSWORD = process.env.REACT_APP_ADMIN_PASSWORD ?? "letmein";
+
+export const AdminDashboard: React.FC<AdminDashboardProps> = ({
+  baseUrl,
+  setBaseUrl,
+  simCount,
+  setSimCount,
+  busy,
+  error,
+  onPullFromSpond,
+  onShuffle,
+  onLoadSaved,
+}) => {
+  const [passwordInput, setPasswordInput] = useState("");
+  const [isUnlocked, setIsUnlocked] = useState(false);
+  const [authError, setAuthError] = useState<string | null>(null);
+
+  const maskedBaseUrl = useMemo(() => {
+    try {
+      const url = new URL(baseUrl);
+      return `${url.protocol}//${url.host}`;
+    } catch (e) {
+      return baseUrl;
+    }
+  }, [baseUrl]);
+
+  const handleAuth = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (passwordInput.trim() === ADMIN_PASSWORD) {
+      setIsUnlocked(true);
+      setAuthError(null);
+      setPasswordInput("");
+    } else {
+      setAuthError("Incorrect password. Please try again.");
+    }
+  };
+
+  return (
+    <main className="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-10">
+      <section className="rounded-3xl border border-slate-200 bg-white p-8 shadow-xl">
+        <header className="mb-6 flex flex-col gap-2">
+          <span className="text-xs font-semibold uppercase tracking-widest text-emerald-600">Admin</span>
+          <h1 className="text-3xl font-bold text-slate-900">Control Center</h1>
+          <p className="text-sm text-slate-500">
+            Manage integrations, shuffles and data sources. Changes here affect what everyone sees on the
+            public dashboard.
+          </p>
+        </header>
+
+        {!isUnlocked ? (
+          <form onSubmit={handleAuth} className="mt-6 flex flex-col gap-4 rounded-2xl border border-slate-200 bg-slate-50 p-6">
+            <div>
+              <label htmlFor="admin-password" className="block text-sm font-medium text-slate-600">
+                Admin password
+              </label>
+              <input
+                id="admin-password"
+                type="password"
+                value={passwordInput}
+                onChange={(event) => setPasswordInput(event.target.value)}
+                className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-3 text-base shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                placeholder="Enter password"
+                autoComplete="current-password"
+                required
+              />
+            </div>
+            {authError && <div className="rounded-xl bg-red-50 p-3 text-sm text-red-700">{authError}</div>}
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2"
+            >
+              Unlock controls
+            </button>
+            <p className="text-xs text-slate-500">
+              The default password can be overridden by setting <code className="font-semibold">REACT_APP_ADMIN_PASSWORD</code>
+              in your environment.
+            </p>
+          </form>
+        ) : (
+          <div className="space-y-8">
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-6">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h2 className="text-base font-semibold text-slate-800">Connected API</h2>
+                  <p className="text-sm text-slate-500">Base endpoint currently pointed at {maskedBaseUrl || "—"}.</p>
+                </div>
+              </div>
+              <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+                <input
+                  value={baseUrl}
+                  onChange={(event) => setBaseUrl(event.target.value)}
+                  placeholder="API base URL (e.g., http://localhost:8000)"
+                  className="flex-1 rounded-xl border border-slate-300 px-4 py-3 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                />
+                <button
+                  type="button"
+                  onClick={onLoadSaved}
+                  disabled={!!busy}
+                  className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm font-medium text-slate-700 shadow-sm transition hover:border-emerald-500 hover:text-emerald-600 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Refresh groups
+                </button>
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-6">
+              <h2 className="text-base font-semibold text-slate-800">Simulator controls</h2>
+              <div className="mt-4 grid gap-4 sm:grid-cols-[1fr_auto] sm:items-center">
+                <div>
+                  <label className="text-sm font-medium text-slate-600">Simulators</label>
+                  <div className="mt-2 flex items-center gap-3">
+                    <input
+                      type="number"
+                      min={1}
+                      className="w-24 rounded-xl border border-slate-300 px-3 py-2 text-base shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                      value={simCount}
+                      onChange={(event) => setSimCount(Math.max(1, Number(event.target.value) || 1))}
+                    />
+                    <span className="text-xs uppercase tracking-widest text-slate-500">Slots</span>
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-2 sm:justify-self-end">
+                  <button
+                    type="button"
+                    onClick={onShuffle}
+                    disabled={!!busy}
+                    className="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-semibold text-white shadow-lg transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Shuffle &amp; publish
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onPullFromSpond}
+                    disabled={!!busy}
+                    className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 shadow-sm transition hover:border-emerald-500 hover:text-emerald-600 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Pull from Spond
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {(busy || error) && (
+              <div className="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-600 shadow-sm">
+                {busy && <div className="font-semibold text-emerald-600">{busy}…</div>}
+                {error && <div className="mt-2 rounded-xl bg-red-50 p-3 text-red-700">{error}</div>}
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+};
+

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,130 +1,39 @@
 
-import React, { useEffect, useMemo, useState } from "react";
-import { api, ApiClient } from "../api/client";
-import type { Attendee, Group, ShuffleResponse } from "../types";
-import { useLocalStorage } from "../hooks/useLocalStorage";
+import React from "react";
+import type { Group } from "../types";
 import { GroupGrid } from "../components/GroupGrid";
+interface DashboardProps {
+  groups: Group[] | null;
+  busy: string | null;
+  error: string | null;
+}
 
-const LS_KEY_BASEURL = "sims.api.baseurl";
-
-export const Dashboard: React.FC = () => {
-  const [baseUrl, setBaseUrl] = useLocalStorage(LS_KEY_BASEURL, api.baseUrl);
-  const client = useMemo(() => new ApiClient(baseUrl), [baseUrl]);
-
-  const [groups, setGroups] = useState<Group[] | null>(null);
-  const [simCount, setSimCount] = useState<number>(4);
-  const [busy, setBusy] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  async function safe<T>(label: string, fn: () => Promise<T>): Promise<T | null> {
-    setBusy(label);
-    setError(null);
-    try {
-      const out = await fn();
-      return out;
-    } catch (e) {
-      setError((e as Error).message);
-      return null;
-    } finally {
-      setBusy(null);
-    }
-  }
-
-  // Initial load
-  useEffect(() => {
-
-    safe("Loading groups", async () => {
-      const data = await client.getGroups();
-      setGroups(data);
-      return null;
-    });
-  }, [client]);
-
+export const Dashboard: React.FC<DashboardProps> = ({ groups, busy, error }) => {
   return (
-    <div className="mx-auto max-w-6xl p-4 space-y-6">
-      <header className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
-        <div>
-          <h1 className="text-2xl font-bold">Spond Sims</h1>
-          <p className="text-sm opacity-80">Frontend for your FastAPI groups/attendees service.</p>
-        </div>
-        <div className="flex items-center gap-2">
-          <input
-            className="w-[24rem] rounded-xl border px-3 py-2 text-sm"
-            value={baseUrl}
-            onChange={(e) => setBaseUrl(e.target.value)}
-            placeholder="API base URL (e.g., http://localhost:8000)"
-          />
-        </div>
-      </header>
-
-      {error && (
-        <div className="rounded-xl border border-red-300 bg-red-50 p-3 text-sm text-red-800">
-          {error}
-        </div>
-      )}
-
-      <section className="space-y-3">
-        <div className="flex flex-wrap items-center gap-2">
-          <button
-            disabled={!!busy}
-            onClick={() =>
-              safe("Pulling from Spond", async () => {
-                const a = await client.pullFromSpond();
-                return null;
-              })
-            }
-            className="rounded-xl border px-3 py-2 text-sm shadow-sm hover:bg-gray-50 disabled:opacity-60"
-          >
-            Pull from Spond
-          </button>
-
-          <div className="flex items-center gap-2">
-            <label className="text-sm">Simulators:</label>
-            <input
-              type="number"
-              min={1}
-              className="w-20 rounded-xl border px-3 py-2 text-sm"
-              value={simCount}
-              onChange={(e) => setSimCount(Math.max(1, Number(e.target.value)))}
-            />
-            <button
-              disabled={!!busy}
-              onClick={() =>
-                safe("Shuffling groups", async () => {
-                  const res: ShuffleResponse = await client.shuffle(simCount);
-                  setGroups(res.groups);
-                  return null;
-                })
-              }
-              className="rounded-xl border px-3 py-2 text-sm shadow-sm hover:bg-gray-50 disabled:opacity-60"
-            >
-              Shuffle
-            </button>
-            <button
-              disabled={!!busy}
-              onClick={() =>
-                safe("Loading saved groups", async () => {
-                  const g = await client.getGroups();
-                  setGroups(g);
-                  return null;
-                })
-              }
-              className="rounded-xl border px-3 py-2 text-sm shadow-sm hover:bg-gray-50 disabled:opacity-60"
-            >
-              Load saved groups
-            </button>
-
-            {busy && <span className="text-sm italic opacity-70">{busy}…</span>}
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <section className="space-y-8">
+        <header className="flex flex-col gap-3 text-center">
+          <div className="mx-auto inline-flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-1 text-xs font-semibold uppercase tracking-widest text-emerald-700">
+            <span className="inline-block h-2 w-2 rounded-full bg-emerald-500" />
+            Live pairings
           </div>
-        </div>
+          <h1 className="text-4xl font-bold tracking-tight text-slate-900">Tonight&apos;s Simulator Groups</h1>
+          <p className="text-sm text-slate-500">
+            Up to six simulators are supported. For changes or reshuffles please contact an administrator.
+          </p>
+        </header>
 
-        <div className="grid gap-6 md:grid-cols-2">
-          <div>
-            <h2 className="mb-2 text-lg font-semibold">Groups</h2>
-            <GroupGrid groups={groups ?? []} />
+        {(busy || error) && (
+          <div className="mx-auto max-w-xl rounded-3xl border border-slate-200 bg-white/70 p-4 text-center text-sm shadow-sm">
+            {busy && <div className="font-semibold text-emerald-600">{busy}…</div>}
+            {error && <div className="mt-2 text-red-600">{error}</div>}
           </div>
+        )}
+
+        <div className="rounded-3xl border border-slate-200 bg-white/70 p-6 shadow-xl backdrop-blur">
+          <GroupGrid groups={groups ?? []} />
         </div>
       </section>
-    </div>
+    </main>
   );
 };


### PR DESCRIPTION
## Summary
- add a navigational shell that shares API state between the public dashboard and admin console
- create a password-gated admin dashboard and move all API-triggering controls there
- refresh the public dashboard and group cards with larger, simulator-focused styling for up to six groups

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6e4a8824c832f91b7a069e6d30fb3