### PR TITLE
Add admin drag-and-drop group editing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,20 @@ export default function App() {
     [client, safe, simCount]
   );
 
+  const handleSwap = useCallback(
+    (attendeeOne: string, attendeeTwo: string) =>
+      safe("Updating groups", async () => {
+        const res: ShuffleResponse = await client.swap(attendeeOne, attendeeTwo);
+        setGroups(res.groups);
+        setGroupsUpdatedAt(new Date());
+        const flattened = res.groups.flatMap((group) => group.members ?? []);
+        setAttendees(flattened);
+        setAttendeesUpdatedAt(new Date());
+        return res;
+      }),
+    [client, safe]
+  );
+
   const handleLoadSaved = useCallback(
     () =>
       safe("Reloading saved data", async () => {
@@ -140,6 +154,7 @@ export default function App() {
           error={error}
           onPullFromSpond={handlePullFromSpond}
           onShuffle={handleShuffle}
+          onSwap={handleSwap}
           onLoadSaved={handleLoadSaved}
           attendees={attendees}
           groups={groups}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -42,6 +42,13 @@ export class ApiClient {
     return this.req<ShuffleResponse>(`/groups/shuffle?${qs}`, { method: "POST" });
   }
 
+  swap(attendeeOne: string, attendeeTwo: string) {
+    return this.req<ShuffleResponse>("/groups/swap", {
+      method: "POST",
+      body: JSON.stringify({ attendee_one: attendeeOne, attendee_two: attendeeTwo }),
+    });
+  }
+
   getGroups() {
     return this.req<Group[]>("/groups/");
   }


### PR DESCRIPTION
## Summary
- add a swap endpoint helper to the API client and wire it into app state management
- introduce an admin edit mode that supports drag-and-drop or click-to-swap attendee assignments
- refresh the published groups panel with guidance and interactive controls for swapping

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6fa3317c4832fb0f2b2735a6a1f8d