### PR TITLE
Handle new groups API response

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,10 +41,13 @@ export default function App() {
   }, [client]);
 
   const fetchGroups = useCallback(async () => {
-    const data = await client.getGroups();
-    setGroups(data);
+    const res = await client.getGroups();
+    setGroups(res.groups);
+    if (typeof res.sim_count === "number") {
+      setSimCount(res.sim_count);
+    }
     setGroupsUpdatedAt(new Date());
-    return data;
+    return res;
   }, [client]);
 
   const initialize = useCallback(

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,5 @@
 
-import type { Attendee, Group, ShuffleResponse } from "../types";
+import type { Attendee, ShuffleResponse } from "../types";
 
 const DEFAULT_BASE = "https://bsi-golf-api.vercel.app/";
 
@@ -50,7 +50,7 @@ export class ApiClient {
   }
 
   getGroups() {
-    return this.req<Group[]>("/groups/");
+    return this.req<ShuffleResponse>("/groups/");
   }
 }
 


### PR DESCRIPTION
## Summary
- update the API client to expect the new ShuffleResponse shape from `/groups/`
- update the app's group fetch logic to consume the reshaped payload and keep the sim count in sync

## Testing
- npm test -- --watch=false *(fails: existing default CRA test still expects the sample "learn react" link)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ffe7dafc832f937d0c6818f21d8c