### PR TITLE
Disable caching of API responses

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -15,8 +15,14 @@ export class ApiClient {
 
   private async req<T>(path: string, init?: RequestInit): Promise<T> {
     const res = await fetch(`${this.baseUrl}${path}`, {
-      headers: { "Content-Type": "application/json" },
+      cache: "no-store",
       ...init,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache",
+        Pragma: "no-cache",
+        ...init?.headers,
+      },
     });
     if (!res.ok) {
       const text = await res.text().catch(() => "");


### PR DESCRIPTION
## Summary
- ensure API client bypasses browser caches when requesting data
- add no-cache headers so group requests always hit the server

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d70198a840832fafc375553bf8c7d1