### PR TITLE
Fix attendee names being truncated after shuffle

### DIFF
--- a/src/components/GroupCard.tsx
+++ b/src/components/GroupCard.tsx
@@ -1,6 +1,7 @@
 
 import React from "react";
 import type { Group } from "../types";
+import { getDisplayName } from "../utils/displayName";
 
 export const GroupCard: React.FC<{ group: Group; index?: number }> = ({ group }) => {
   return (
@@ -18,14 +19,17 @@ export const GroupCard: React.FC<{ group: Group; index?: number }> = ({ group })
         </div>
 
         <ul className="flex flex-1 flex-col gap-2 text-lg font-medium text-slate-800">
-          {group.members.map((member, index) => (
-            <li key={index} className="flex items-center gap-3 rounded-2xl bg-white/60 px-3 py-2 text-left shadow-sm">
-              <span className="flex h-7 w-7 flex-none items-center justify-center rounded-full bg-emerald-500/80 text-xs font-bold uppercase tracking-widest text-white">
-                {index + 1}
-              </span>
-              <span>{String(member.name ?? member.full_name ?? member.display_name ?? Object.values(member)[0])}</span>
-            </li>
-          ))}
+          {group.members.map((member, index) => {
+            const memberName = getDisplayName(member, index + 1);
+            return (
+              <li key={index} className="flex items-center gap-3 rounded-2xl bg-white/60 px-3 py-2 text-left shadow-sm">
+                <span className="flex h-7 w-7 flex-none items-center justify-center rounded-full bg-emerald-500/80 text-xs font-bold uppercase tracking-widest text-white">
+                  {index + 1}
+                </span>
+                <span>{memberName}</span>
+              </li>
+            );
+          })}
         </ul>
       </div>
     </article>

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useState } from "react";
 import type { Attendee, Group } from "../types";
+import { getDisplayName } from "../utils/displayName";
 
 interface AdminDashboardProps {
   baseUrl: string;
@@ -26,53 +27,6 @@ const formatTimestamp = (value: Date | null) => {
     dateStyle: "medium",
     timeStyle: "short",
   }).format(value);
-};
-
-const getDisplayName = (person: Attendee, fallbackIndex: number) => {
-  if (person == null) {
-    return `Attendee ${fallbackIndex}`;
-  }
-
-  if (typeof person === "string" || typeof person === "number") {
-    return String(person);
-  }
-
-  const record = person as Record<string, unknown>;
-  const primaryKeys = ["name", "full_name", "fullName", "display_name", "displayName"];
-  for (const key of primaryKeys) {
-    const value = record[key];
-    if (typeof value === "string" && value.trim()) {
-      return value.trim();
-    }
-  }
-
-  const firstName =
-    typeof record.first_name === "string"
-      ? record.first_name
-      : typeof record.firstName === "string"
-        ? record.firstName
-        : "";
-  const lastName =
-    typeof record.last_name === "string"
-      ? record.last_name
-      : typeof record.lastName === "string"
-        ? record.lastName
-        : "";
-
-  const combined = `${firstName} ${lastName}`.trim();
-  if (combined) {
-    return combined;
-  }
-
-  if (typeof record.email === "string" && record.email.trim()) {
-    return record.email.trim();
-  }
-
-  if (record.id != null) {
-    return `#${record.id}`;
-  }
-
-  return `Attendee ${fallbackIndex}`;
 };
 
 export const AdminDashboard: React.FC<AdminDashboardProps> = ({

--- a/src/utils/displayName.ts
+++ b/src/utils/displayName.ts
@@ -1,0 +1,49 @@
+import type { Attendee } from "../types";
+
+export const getDisplayName = (person: Attendee, fallbackIndex: number) => {
+  if (person == null) {
+    return `Attendee ${fallbackIndex}`;
+  }
+
+  if (typeof person === "string" || typeof person === "number") {
+    return String(person);
+  }
+
+  const record = person as Record<string, unknown>;
+  const primaryKeys = ["name", "full_name", "fullName", "display_name", "displayName"] as const;
+
+  for (const key of primaryKeys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  const firstName =
+    typeof record.first_name === "string"
+      ? record.first_name
+      : typeof record.firstName === "string"
+        ? record.firstName
+        : "";
+  const lastName =
+    typeof record.last_name === "string"
+      ? record.last_name
+      : typeof record.lastName === "string"
+        ? record.lastName
+        : "";
+
+  const combined = `${firstName} ${lastName}`.trim();
+  if (combined) {
+    return combined;
+  }
+
+  if (typeof record.email === "string" && record.email.trim()) {
+    return record.email.trim();
+  }
+
+  if (record.id != null) {
+    return `#${record.id}`;
+  }
+
+  return `Attendee ${fallbackIndex}`;
+};


### PR DESCRIPTION
## Summary
- extract a reusable getDisplayName helper so attendee names are derived consistently
- update the admin dashboard and group cards to use the shared helper for member labels

## Testing
- npm test -- --watch=false *(fails: existing sample test expects "learn react" link)*

------
https://chatgpt.com/codex/tasks/task_e_68d705c972d8832fbb1bca47eafb1098