### PR TITLE
Display roster with member attendance status

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,5 @@
 
-import type { Attendee, ShuffleResponse } from "../types";
+import type { Attendee, Member, ShuffleResponse } from "../types";
 
 const DEFAULT_BASE = "https://bsi-golf-api.vercel.app/";
 
@@ -41,6 +41,14 @@ export class ApiClient {
 
   getAttendees() {
     return this.req<Attendee[]>("/attendees/");
+  }
+
+  getMembers() {
+    return this.req<Member[]>("/members/");
+  }
+
+  getMembersNotAttendingNextEvent() {
+    return this.req<Member[]>("/members/notAttendingNextEvent");
   }
 
   shuffle(simCount: number) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export type UnknownRecord = Record<string, any>;
 
 export type Attendee = UnknownRecord; // schema-agnostic
+export type Member = UnknownRecord; // schema-agnostic
 
 export type Group = {
   group_id: number;


### PR DESCRIPTION
## Summary
- fetch roster data from the new members endpoints alongside attendees
- pass member and non-attending lists into the admin dashboard
- render the full roster with status chips so attending members appear green and non-attendees red

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7b3ec5d6c832fab1227061902c607